### PR TITLE
Fixed unity crash when connection to master server failed

### DIFF
--- a/BeardedManStudios/Source/Forge/Networking/TCPClientBase.cs
+++ b/BeardedManStudios/Source/Forge/Networking/TCPClientBase.cs
@@ -287,24 +287,27 @@ namespace BeardedManStudios.Forge.Networking
 		/// <param name="forced">Used to tell if this disconnect was intentional <c>false</c> or caused by an exception <c>true</c></param>
 		public override void Disconnect(bool forced)
 		{
-			lock (client)
+			if (client != null)
 			{
-				disconnectedSelf = true;
+				lock (client)
+				{
+					disconnectedSelf = true;
 
-				// Close our TcpClient so that it can no longer be used
-				if (forced)
-					client.Close();
-				else
-					Send(new ConnectionClose(Time.Timestep, true, Receivers.Server, MessageGroupIds.DISCONNECT, true));
+					// Close our TcpClient so that it can no longer be used
+					if (forced)
+						client.Close();
+					else
+						Send(new ConnectionClose(Time.Timestep, true, Receivers.Server, MessageGroupIds.DISCONNECT, true));
 
-				// Send signals to the methods registered to the disconnec events
-				if (!forced)
-					OnDisconnected();
-				else
-					OnForcedDisconnect();
+					// Send signals to the methods registered to the disconnec events
+					if (!forced)
+						OnDisconnected();
+					else
+						OnForcedDisconnect();
 
-				for (int i = 0; i < Players.Count; ++i)
-					OnPlayerDisconnected(Players[i]);
+					for (int i = 0; i < Players.Count; ++i)
+						OnPlayerDisconnected(Players[i]);
+				}
 			}
 		}
 

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
@@ -245,6 +245,12 @@ namespace BeardedManStudios.Forge.Networking.Unity
 					//Debug.Log(temp.GetData().Length);
 					// Send the request to the server
 					client.Send(temp);
+
+					Networker.disconnected += s =>
+					{
+						client.Disconnect(false);
+						MasterServerNetworker = null;
+					};
 				}
 				catch
 				{
@@ -256,11 +262,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 
 			client.Connect(_masterServerHost, _masterServerPort);
 
-			Networker.disconnected += (sender) =>
-			{
-				client.Disconnect(false);
-				MasterServerNetworker = null;
-			};
+			
 
 			MasterServerNetworker = client;
 		}


### PR DESCRIPTION
Those two changes fix the same issue so only one of them is needed. Not sure which one is better.